### PR TITLE
Add run() function

### DIFF
--- a/src/Stack/StackedHttpKernel.php
+++ b/src/Stack/StackedHttpKernel.php
@@ -31,4 +31,15 @@ class StackedHttpKernel implements HttpKernelInterface, TerminableInterface
             }
         }
     }
+
+    public function run(Request $request = null)
+    {
+        if (null === $request) {
+            $request = Request::createFromGlobals();
+        }
+
+        $response = $this->handle($request);
+        $response->send();
+        $this->terminate($request, $response);
+    }
 }


### PR DESCRIPTION
I think that  run() function could be helpful (in the same way than it's in Silex). It's just a shortcut, especially when we are going to use the Request from globals (but maybe there's a good reason to not to include it in StackedHttpKernel)
