### PR TITLE
Build safe chain of terminable kernels (fixes #10)

### DIFF
--- a/tests/unit/Stack/BuilderTest.php
+++ b/tests/unit/Stack/BuilderTest.php
@@ -21,7 +21,6 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
         $request = Request::create('/');
         $response = $resolved->handle($request);
 
-        $this->assertInstanceOf('Stack\StackedHttpKernel', $resolved);
         $this->assertSame('ok', $response->getContent());
     }
 

--- a/tests/unit/Stack/StackedHttpKernelTest.php
+++ b/tests/unit/Stack/StackedHttpKernelTest.php
@@ -13,10 +13,12 @@ class StackedHttpKernelTest extends \PHPUnit_Framework_TestCase
     public function handleShouldDelegateToApp()
     {
         $app = $this->getHttpKernelMock(new Response('ok'));
-        $kernel = new StackedHttpKernel($app, array($app));
+        $prev = $this->getTerminableMock();
+        $kernel = new StackedHttpKernel($app, $prev);
 
         $request = Request::create('/');
         $response = $kernel->handle($request);
+        $kernel->terminate($request, $response);
 
         $this->assertSame('ok', $response->getContent());
     }


### PR DESCRIPTION
- Should not call terminate() more than once (it was potentially factorial of stack size)
- Allow middlewares to delegate terminate() calls
- Increases stack size by number of non-terminable middlewares wrapping a terminable

If possible, we should find a way to reduce stack size, as it is expensive for GC.

Note: This implementation implicitly defines the semantics of Terminable to be as follows. A middleware that implements Terminable _must_ always delegate to the next layer. If Terminable is not implemented, it will be wrapped in a StackedHttpKernel that handles the terminate() delegation. The delegation _must not_ be conditional.

A consequence of this is that all middlewares will be called every time, each one exactly once.
