### PR TITLE
upd travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 before_script:
-  - composer self-update
   - composer install --no-interaction --prefer-source
 
 script: phpunit --coverage-text


### PR DESCRIPTION
and fix 5.3.3 - SSL extensions not fully working in PHP 5.3.3, causing composer install to fail.