### PR TITLE
tweaked code

### DIFF
--- a/src/Stack/Builder.php
+++ b/src/Stack/Builder.php
@@ -41,17 +41,15 @@ class Builder
     {
         $middlewares = array($app);
 
-        foreach ($this->specs as $spec) {
-            $args = $spec;
+        foreach ($this->specs as $args) {
             $firstArg = array_shift($args);
 
             if (is_callable($firstArg)) {
                 $app = $firstArg($app);
             } else {
-                $kernelClass = $firstArg;
                 array_unshift($args, $app);
 
-                $reflection = new \ReflectionClass($kernelClass);
+                $reflection = new \ReflectionClass($firstArg);
                 $app = $reflection->newInstanceArgs($args);
             }
 


### PR DESCRIPTION
`$args = $spec;`
variable $spec not used in code

` $kernelClass = $firstArg;`

$kernelClass only used as replacement $firstArg for new instance of reflection class