### PR TITLE
Support Symfony 6.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
     ],
     "require": {
         "php": ">=7.2.0",
-        "symfony/http-foundation": "~2.1|~3.0|~4.0|~5.0",
-        "symfony/http-kernel": "~2.1|~3.0|~4.0|~5.0"
+        "symfony/http-foundation": "~2.1|~3.0|~4.0|~5.0|~6.0",
+        "symfony/http-kernel": "~2.1|~3.0|~4.0|~5.0|~6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~8.0",
-        "symfony/routing": "^5.0"
+        "symfony/routing": "^5.0|^6.0"
     },
     "scripts": {
         "test": "phpunit --coverage-text"


### PR DESCRIPTION
Drupal uses stack/builder and we're working on Symfony 6 compatibility for our upcoming Drupal 10 release. A new release with these constraints would be great if that's doable.