### PR TITLE
Symfony 6 and PHPUnit 9.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
     ],
     "require": {
         "php": ">=7.2.0",
-        "symfony/http-foundation": "~2.1|~3.0|~4.0|~5.0",
-        "symfony/http-kernel": "~2.1|~3.0|~4.0|~5.0"
+        "symfony/http-foundation": "~2.1|~3.0|~4.0|~5.0|~6.0",
+        "symfony/http-kernel": "~2.1|~3.0|~4.0|~5.0|~6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~8.0",
-        "symfony/routing": "^5.0"
+        "phpunit/phpunit": "~9.0",
+        "symfony/routing": "^6.0"
     },
     "scripts": {
         "test": "phpunit --coverage-text"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,9 +11,6 @@
         <testsuite name="unit">
             <directory>./tests/unit/</directory>
         </testsuite>
-        <testsuite name="integration">
-            <directory>./tests/integration/</directory>
-        </testsuite>
         <testsuite name="functional">
             <directory>./tests/functional/</directory>
         </testsuite>

--- a/src/Stack/StackedHttpKernel.php
+++ b/src/Stack/StackedHttpKernel.php
@@ -18,7 +18,7 @@ class StackedHttpKernel implements HttpKernelInterface, TerminableInterface
         $this->middlewares = $middlewares;
     }
 
-    public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
+    public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true): Response
     {
         return $this->app->handle($request, $type, $catch);
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -44,7 +44,7 @@ class Application implements HttpKernelInterface
         $this->kernel = new HttpKernel($this->dispatcher, $controllerResolver, new RequestStack(), $argumentResolver);
     }
 
-    public function handle(Request $request, int $type = HttpKernelInterface::MASTER_REQUEST, bool $catch = true)
+    public function handle(Request $request, int $type = HttpKernelInterface::MASTER_REQUEST, bool $catch = true): Response
     {
         return $this->kernel->handle($request);
     }

--- a/tests/functional/ApplicationTest.php
+++ b/tests/functional/ApplicationTest.php
@@ -6,6 +6,7 @@ use Application;
 use PHPUnit\Framework\TestCase;
 use Stack\Builder;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class ApplicationTest extends TestCase
@@ -45,7 +46,7 @@ class Append implements HttpKernelInterface
         $this->appendix = $appendix;
     }
 
-    public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
+    public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true): Response
     {
         $response = clone $this->app->handle($request, $type, $catch);
         $response->setContent($response->getContent().$this->appendix);

--- a/tests/unit/Stack/BuilderTest.php
+++ b/tests/unit/Stack/BuilderTest.php
@@ -193,7 +193,7 @@ class Append implements HttpKernelInterface
         $this->appendix = $appendix;
     }
 
-    public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
+    public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true): Response
     {
         $response = clone $this->app->handle($request, $type, $catch);
         $response->setContent($response->getContent().$this->appendix);

--- a/tests/unit/Stack/StackedHttpKernelTest.php
+++ b/tests/unit/Stack/StackedHttpKernelTest.php
@@ -119,7 +119,7 @@ class KernelSpy implements HttpKernelInterface
         $this->kernel = $kernel;
     }
 
-    public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
+    public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true): Response
     {
         $this->handleCallCount++;
 


### PR DESCRIPTION
Drupal uses `stack/builder` and so we need to add Symfony 6 compatibility here for us to be able to upgrade.

Locally the tests pass for me with these changes:

```
$ vendor/bin/phpunit
PHPUnit 9.5.11 by Sebastian Bergmann and contributors.

Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

...............                                                   15 / 15 (100%)

Time: 00:00.021, Memory: 8.00 MB

OK (15 tests, 22 assertions)
```

However the new return type in `StackedHttpKernel::handle()` might mean this has to be a 2.0 release?
